### PR TITLE
Fix 5.19 Kernel NVMe CC info issue

### DIFF
--- a/hw/femu/femu.c
+++ b/hw/femu/femu.c
@@ -90,6 +90,13 @@ static void nvme_write_bar(FemuCtrl *n, hwaddr offset, uint64_t data, unsigned s
         n->bar.intmc = n->bar.intms;
         break;
     case 0x14:
+        /* If first sending data, then sending enable bit */
+        if (!NVME_CC_EN(data) && !NVME_CC_EN(n->bar.cc) &&
+                !NVME_CC_SHN(data) && !NVME_CC_SHN(n->bar.cc))
+        {
+            n->bar.cc = data;
+        }
+
         if (NVME_CC_EN(data) && !NVME_CC_EN(n->bar.cc)) {
             n->bar.cc = data;
             if (nvme_start_ctrl(n)) {


### PR DESCRIPTION
# The problem

This PR addresses https://github.com/DKU-StarLab/ConfZNS/issues/1, ConfZNS does not work on Linux kernels newer than 5.19 because NVMe devices can no longer be initialized correctly.

# Solution

The solution is line for line identical to PR #96 in FEMU by @nicktehrany  (no URL to prevent sending notifications). It would be better to directly pull all FEMU changes into ConfZNS, but both repositories have diverged significantly. An easier solution is to simply copy the commit.