### PR TITLE
Fix zone append latency

### DIFF
--- a/hw/femu/zns/zns.c
+++ b/hw/femu/zns/zns.c
@@ -1300,6 +1300,13 @@ static uint64_t znsssd_write(ZNS *zns, NvmeRequest *req){
     uint32_t nlb = (uint32_t)le16_to_cpu(rw->nlb) + 1;
     uint64_t currlat = 0, maxlat= 0;
 
+    // To get accurate append latency we need to change the slba to the zone pointer (we do not send all requests to slba even for appends).
+    {
+        NvmeZone *zone;
+        zone = zns_get_zone_by_slba(ns, slba);
+        slba = zone->w_pt
+    }
+
     uint64_t nand_stime =0;
     uint64_t cmd_stime = 0;
     zns_ssd_channel *chnl =NULL;


### PR DESCRIPTION
Hello all,

Currently there is a small issue for the timing model of `Zone Appends` in ConfZNS. 
`Zone Appends` are correctly translated from the head of the zone to the write pointer of the zone for all `memcpys` (`backend_rw`) and state management (`zns_advance_zone_wp`). However, this is not done yet for the timing model, resulting in inaccurate performance.

# The problem

`zns_advance_status` uses the zone pointer for `zone appends` (retrieved from `req->cmd->slba`), not `zone->w_ptr`.
See the comments below:
```C
    if (append) {
       // slba is correctly set to the write pointer.
        slba = zone->w_ptr;
    }
    res->slba = zns_advance_zone_wp(ns, zone, nlb);

    data_offset = zns_l2b(ns, slba);

    if (!wrz) {
        status = zns_map_dptr(n, data_size, req);
        if (status) {
            goto err;
        }
        // zns_advance_status uses the lba from req, which is still the zone head, not the write pointer (e.g., slba).
        req->expire_time += zns_advance_status(n,ns,&req->cmd,req);
        backend_rw(n->mbe, &req->qsg, &data_offset, req->is_write);
    }
    zns_finalize_zoned_write(ns, req, false);
``` 
As a result the timing model sees all appends to a zone as pointing to the same physical address and `Zone Appends` can not scale. The timing model should use the wp as well and not the zone head.

# Possible solution

I have attached a possible solution to the problem.
It forces the lba to the wp for all `writes` and `zone appends` in `zns_advance_status`.
Let me know what you think of the fix, as it might not be the most elegant approach?