### PR TITLE
Resolve compilation issue in zns.c

### DIFF
--- a/hw/femu/zns/zns.c
+++ b/hw/femu/zns/zns.c
@@ -1304,7 +1304,7 @@ static uint64_t znsssd_write(ZNS *zns, NvmeRequest *req){
     {
         NvmeZone *zone;
         zone = zns_get_zone_by_slba(ns, slba);
-        slba = zone->w_pt
+        slba = zone->w_ptr;
     }
 
     uint64_t nand_stime =0;


### PR DESCRIPTION
Hi @inhoinno ,

There is a small typo in `zns.c`. This was introduced by accident in `39cbe032563a69b9d93ab497569b99926b110d6d`. I have modified the code to solve the issue.